### PR TITLE
Solved didSelectItemAtIndexPath issue #7

### DIFF
--- a/Example/DisplaySwitcher/Base.lproj/Main.storyboard
+++ b/Example/DisplaySwitcher/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="KUR-je-Sh7">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="KUR-je-Sh7">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -82,12 +82,9 @@
                             <constraint firstItem="H8x-eM-1GS" firstAttribute="top" secondItem="Oi6-wZ-g76" secondAttribute="bottom" id="pPq-nq-yXI"/>
                             <constraint firstItem="hZF-AP-KvR" firstAttribute="top" secondItem="H8x-eM-1GS" secondAttribute="bottom" id="tgn-L8-bqe"/>
                         </constraints>
-                        <connections>
-                            <outletCollection property="gestureRecognizers" destination="ucw-iF-foi" appends="YES" id="P8B-l5-rvR"/>
-                        </connections>
                     </view>
                     <navigationItem key="navigationItem" title="Friends" id="IHB-pf-cHm">
-                        <barButtonItem key="rightBarButtonItem" width="60" style="plain" id="R8D-p0-NGA">
+                        <barButtonItem key="rightBarButtonItem" width="60" id="R8D-p0-NGA">
                             <view key="customView" contentMode="scaleToFill" id="70Y-rH-SbY" userLabel="Container View">
                                 <rect key="frame" x="233" y="5" width="71" height="33"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -132,12 +129,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="22m-rT-erS" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="ucw-iF-foi">
-                    <connections>
-                        <action selector="tapRecognized" destination="GxX-QO-EZ4" id="ZEa-X7-XVF"/>
-                        <outlet property="delegate" destination="GxX-QO-EZ4" id="Vwf-80-4Hd"/>
-                    </connections>
-                </tapGestureRecognizer>
                 <customObject id="rx3-CL-HDB"/>
             </objects>
             <point key="canvasLocation" x="656" y="464"/>

--- a/Example/DisplaySwitcher/ViewControllers/UserViewController/UserViewController.swift
+++ b/Example/DisplaySwitcher/ViewControllers/UserViewController/UserViewController.swift
@@ -32,6 +32,8 @@ class UserViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
       
+        tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        
         searchUsers = users
         rotationButton.selected = true
         setupCollectionView()
@@ -118,13 +120,11 @@ extension UserViewController {
         collectionView.reloadData()
     }
     
-    func collectionView(collectionView: UICollectionView,
-                        didSelectItemAtIndexPath indexPath: NSIndexPath) {
+    func collectionView(collectionView: UICollectionView,didSelectItemAtIndexPath indexPath: NSIndexPath) {
         print("Hi \(indexPath.row)")
     }
     
     func searchBarTextDidBeginEditing(searchBar: UISearchBar) {
-        tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         view.addGestureRecognizer(tap)
     }
     

--- a/Example/DisplaySwitcher/ViewControllers/UserViewController/UserViewController.swift
+++ b/Example/DisplaySwitcher/ViewControllers/UserViewController/UserViewController.swift
@@ -20,6 +20,7 @@ class UserViewController: UIViewController {
     @IBOutlet private weak var searchBar: UISearchBar!
     @IBOutlet private weak var rotationButton: RotationButton!
     
+    private var tap:UITapGestureRecognizer!
     private var users = UserDataProvider().generateFakeUsers()
     private var searchUsers = [User]()
     private var isTransitionAvailable = true
@@ -34,18 +35,12 @@ class UserViewController: UIViewController {
         searchUsers = users
         rotationButton.selected = true
         setupCollectionView()
-        addGestureRecognizerToNavBar()
     }
     
     // MARK: - Private methods
     private func setupCollectionView() {
         collectionView.collectionViewLayout = listLayout
         collectionView.registerNib(UserCollectionViewCell.cellNib, forCellWithReuseIdentifier:UserCollectionViewCell.id)
-    }
-    
-    private func addGestureRecognizerToNavBar() {
-        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(UserViewController.tapRecognized))
-        navigationController!.navigationBar.addGestureRecognizer(tapRecognizer)
     }
     
     // MARK: - Actions
@@ -123,5 +118,24 @@ extension UserViewController {
         collectionView.reloadData()
     }
     
+    func collectionView(collectionView: UICollectionView,
+                        didSelectItemAtIndexPath indexPath: NSIndexPath) {
+        print("Hi \(indexPath.row)")
+    }
+    
+    func searchBarTextDidBeginEditing(searchBar: UISearchBar) {
+        
+        tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        
+        view.addGestureRecognizer(tap)
+    }
+    
+    func searchBarTextDidEndEditing(searchBar: UISearchBar) {
+        view.removeGestureRecognizer(tap)
+    }
+    
+    func handleTap() {
+        view.endEditing(true)
+    }
 }
     

--- a/Example/DisplaySwitcher/ViewControllers/UserViewController/UserViewController.swift
+++ b/Example/DisplaySwitcher/ViewControllers/UserViewController/UserViewController.swift
@@ -20,7 +20,7 @@ class UserViewController: UIViewController {
     @IBOutlet private weak var searchBar: UISearchBar!
     @IBOutlet private weak var rotationButton: RotationButton!
     
-    private var tap:UITapGestureRecognizer!
+    private var tap: UITapGestureRecognizer!
     private var users = UserDataProvider().generateFakeUsers()
     private var searchUsers = [User]()
     private var isTransitionAvailable = true
@@ -124,9 +124,7 @@ extension UserViewController {
     }
     
     func searchBarTextDidBeginEditing(searchBar: UISearchBar) {
-        
         tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
-        
         view.addGestureRecognizer(tap)
     }
     


### PR DESCRIPTION
Hi,

I opened didSelectItemAtIndexPath issue #7 then I solved it in this PR.

No need for gesture recognizer as it disable the cell tap. So I just added gesture recognizer when searchBarTextDidBeginEditing so that the keyboard will disappear when the user tap. Then I removed    gesture recognizer when searchBarTextDidEndEditing.

Note that I added:

```
func collectionView(collectionView: UICollectionView,
                        didSelectItemAtIndexPath indexPath: NSIndexPath) {
        print("Hi \(indexPath.row)")
    }
```

Just to check the functionality so maybe it better to move to new view or any suggestions?

Thanks.

